### PR TITLE
[이재원] sprint3

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,16 +13,30 @@
     />
     <link rel="stylesheet" href="styles/global.css" />
     <link rel="stylesheet" href="styles/home.css" />
-    <meta property="og:image" content="images/logo/panda-market-logo.png" />
-    <meta property="og:url" content="clinquant-dango-4ebd25.netlify.app" />
+    <meta
+      property="og:image"
+      content="https://clinquant-dango-4ebd25.netlify.app/images/logo/panda-market-logo.png"
+    />
+    <meta
+      property="og:url"
+      content="https://clinquant-dango-4ebd25.netlify.app"
+    />
     <meta property="og:title" content="판다마켓" />
-    <meta property="og:description" content="일상믜 모든 물건을 거래해보세요" />
-    <meta name="twitter:image" content="images/logo/panda-market-logo.png" />
-    <meta name="twitter:url" content="clinquant-dango-4ebd25.netlify.app" />
+    <meta property="og:description" content="일상의 모든 물건을 거래해보세요" />
+
+    <meta name="twitter:card" content="summary" />
+    <meta
+      name="twitter:image"
+      content="https://clinquant-dango-4ebd25.netlify.app/images/logo/panda-market-logo.png"
+    />
+    <meta
+      name="twitter:url"
+      content="https://clinquant-dango-4ebd25.netlify.app"
+    />
     <meta name="twitter:title" content="판다마켓" />
     <meta
       name="twitter:description"
-      content="일상믜 모든 물건을 거래해보세요"
+      content="일상의 모든 물건을 거래해보세요"
     />
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -13,12 +13,18 @@
     />
     <link rel="stylesheet" href="styles/global.css" />
     <link rel="stylesheet" href="styles/home.css" />
-    <meta property="og: title" content="판다마켓" />
-    <meta property="og:description" content="일상믜 모든 물건을 거래해보세요" />
     <meta property="og:image" content="/styles/logo/panda-market-logo.png" />
     <meta property="og:url" content="/" />
+    <meta property="og: title" content="판다마켓" />
+    <meta property="og:description" content="일상믜 모든 물건을 거래해보세요" />
+    <meta name="twitter:image" content="/styles/logo/panda-market-logo.png" />
+    <meta name="twitter:url" content="/" />
+    <meta name="twitter: title" content="판다마켓" />
+    <meta
+      name="twitter:description"
+      content="일상믜 모든 물건을 거래해보세요"
+    />
   </head>
-
   <body>
     <header>
       <a href="/"

--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@
     />
     <link rel="stylesheet" href="styles/global.css" />
     <link rel="stylesheet" href="styles/home.css" />
+    <meta property="og: title" content="판다마켓" />
+    <meta property="og:description" content="일상믜 모든 물건을 거래해보세요" />
+    <meta property="og:image" content="/styles/logo/panda-market-logo.png" />
+    <meta property="og:url" content="/" />
   </head>
 
   <body>

--- a/index.html
+++ b/index.html
@@ -13,13 +13,13 @@
     />
     <link rel="stylesheet" href="styles/global.css" />
     <link rel="stylesheet" href="styles/home.css" />
-    <meta property="og:image" content="/styles/logo/panda-market-logo.png" />
-    <meta property="og:url" content="/" />
-    <meta property="og: title" content="판다마켓" />
+    <meta property="og:image" content="images/logo/panda-market-logo.png" />
+    <meta property="og:url" content="clinquant-dango-4ebd25.netlify.app" />
+    <meta property="og:title" content="판다마켓" />
     <meta property="og:description" content="일상믜 모든 물건을 거래해보세요" />
-    <meta name="twitter:image" content="/styles/logo/panda-market-logo.png" />
-    <meta name="twitter:url" content="/" />
-    <meta name="twitter: title" content="판다마켓" />
+    <meta name="twitter:image" content="images/logo/panda-market-logo.png" />
+    <meta name="twitter:url" content="clinquant-dango-4ebd25.netlify.app" />
+    <meta name="twitter:title" content="판다마켓" />
     <meta
       name="twitter:description"
       content="일상믜 모든 물건을 거래해보세요"

--- a/styles/global.css
+++ b/styles/global.css
@@ -102,3 +102,23 @@ h1 {
   border-radius: 999px;
   padding: 16px 124px;
 }
+
+/* Tablet 사이즈 */
+@media (max-width: 1199px) {
+  header {
+    padding: 0 24px;
+  }
+  footer {
+    gap: 16px;
+  }
+}
+
+/* Mobile 사이즈 */
+@media (max-width: 767px) {
+  header {
+    margin: 0 16px;
+  }
+  footer {
+    gap: 8px;
+  }
+}

--- a/styles/login-signup.css
+++ b/styles/login-signup.css
@@ -111,3 +111,23 @@
   color: #3692ff;
   text-decoration: underline;
 }
+
+/* Mobile 사이즈 */
+@media (max-width: 767px) {
+  .login-page,
+  .signup-page {
+    max-width: 400px;
+  }
+
+  .login-log,
+  .signup-logo {
+    width: 198px;
+    height: 66px;
+  }
+
+  .login-content,
+  .signup-content {
+    padding: 0 16px;
+    max-width: 400px;
+  }
+}


### PR DESCRIPTION
## 요구사항

### 기본
랜딩 페이지
- [x] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.
로그인, 회원가입 페이지 공통
- [x] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다
- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.
### 심화

- [x] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [x] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [x] 주소와 이미지는 자유롭게 설정하세요.
## 주요 변경사항

-
-

## 스크린샷

![image](이미지url)

## 멘토에게

- 조건은 다 달성했으나 반응형 웹 디자인을 할 때 다른 요소들도 더 자연스럽게 배치되게 하고 싶습니다. 이럴 때에는 그냥 제가 여러 가지를 시도해 보는 게 좋은 걸까요? 아니면 어느 정도의 방향성이 정해져 있는 지 궁금합니다.
- 랜딩 페이지를 미리 보기 할 때 다 기능하였는데 페이스북만 규정 이미지 크기가 맞지 않아 나오지 않았습니다. 이럴 때에는 이미지를 따로 만들어서 저장해서 사용해 하는 지 궁금합니다.
- 이번에 반응형을 처음 설정해 봤는데 반응형 디자인은 어떤 식으로 요소들을 더 조정해야 더 보기 좋은 웹 페이지를 만들 수 있는 지에 대해 궁급합니다.
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
