### PR TITLE
[최지은]sprint4

### DIFF
--- a/css/auth.css
+++ b/css/auth.css
@@ -4,11 +4,14 @@
 *{
   color: var(--gray-800);
 }
+html, body{
+  height: 100%;
+}
 
-.auth_wrapper{
+.auth_container{
+  min-height: 100%;
+  min-width: 16rem;
   display: flex;
-  height: 100vh;
-  width: 100%;
   align-items: center;
   justify-content: center;
 }
@@ -95,6 +98,7 @@
 }
 
 .simple_login span{
+  word-break: keep-all;
   font-weight: 500;
 }
 .sns_login{
@@ -112,8 +116,7 @@
 
 @media screen and (max-width: 767px) {
   
-  .auth_wrapper{
-    height: 100%;
+  .auth_container{
     padding: 1rem;
   }
 

--- a/css/auth.css
+++ b/css/auth.css
@@ -55,14 +55,20 @@ html, body{
   padding: 0 1.5rem;
 }
 
+.error_text{
+  position: absolute;
+  bottom: -1rem; left: 0;
+  font-size: 0.875rem;
+  color: #ff0000;
+}
+
 .auth.btn{
   font-size: 1.25rem;
   font-weight: 600;
   background-color: var(--gray-400);
-  cursor: unset;
 }
 
-.password_view{
+.input_warp{
   position: relative;
 }
 .password_icon{

--- a/faq.html
+++ b/faq.html
@@ -16,8 +16,8 @@
     <meta name="twitter:image" content="https://pandamarket-jieun.netlify.app/image/meta_padamarket.png" />
     <!-- 링크 -->
     <title>판다마켓</title>
-    <link rel="stylesheet" href="css/import.css" />
-    <link rel="icon" href="image/logo.png" />
+    <link rel="stylesheet" href="/css/import.css" />
+    <link rel="icon" href="/image/logo.png" />
   </head>
   <body>
     <!-- 작업 전 -->

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
           <h2>일상의 모든 물건을 거래해 보세요</h2>
           <a href="/items" class="shopping btn text_tall">구매하러 가기</a>
         </div>
-        <img src="../image/img_home_top.png" alt="intro panda">
+        <img src="/image/img_home_top.png" alt="intro panda">
       </div>
     </section>
 
@@ -47,7 +47,7 @@
       <div class="width_container">
         <ul class="card_outter">
           <li class="card">
-            <img src="image/Img_home_01.png" alt="인기 상품" />
+            <img src="/image/Img_home_01.png" alt="인기 상품" />
             <div class="card_info">
               <span>Hot item</span>
               <h2>인기 상품을 확인해 보세요</h2>
@@ -55,7 +55,7 @@
             </div>
           </li>
           <li class="card right">
-            <img src="image/Img_home_02.png" alt="원하는 상품" />
+            <img src="/image/Img_home_02.png" alt="원하는 상품" />
             <div class="card_info">
               <span>Search</span>
               <h2>구매를 원하는 상품을 검색하세요</h2>
@@ -63,7 +63,7 @@
             </div>
           </li>
           <li class="card">
-            <img src="image/Img_home_03.png" alt="상품 등록" />
+            <img src="/image/Img_home_03.png" alt="상품 등록" />
             <div class="card_info">
               <span>Register</span>
               <h2>판매를 원하는 상품을 등록하세요</h2>
@@ -77,7 +77,7 @@
     <section class="ending">
       <div class="width_container flex_div">
         <div class="title_div"><h2>믿을 수 있는<br>판다마켓 중고 거래</h2></div>
-        <img src="../image/img_home_bottom.png" alt="ending panda">
+        <img src="/image/img_home_bottom.png" alt="ending panda">
         
       </div>
     </section>
@@ -98,17 +98,17 @@
             </li>
             <li>
               <a href="https://x.com/" target="_blank"
-                ><img src="image/sns02.png" alt="X"
+                ><img src="/image/sns02.png" alt="X"
               /></a>
             </li>
             <li>
               <a href="https://www.youtube.com/" target="_blank"
-                ><img src="image/sns03.png" alt="youtube"
+                ><img src="/image/sns03.png" alt="youtube"
               /></a>
             </li>
             <li>
               <a href="https://www.instagram.com/" target="_blank"
-                ><img src="image/sns04.png" alt="instagram"
+                ><img src="/image/sns04.png" alt="instagram"
               /></a>
             </li>
           </ol>

--- a/items.html
+++ b/items.html
@@ -16,8 +16,8 @@
     <meta name="twitter:image" content="https://pandamarket-jieun.netlify.app/image/meta_padamarket.png" />
     <!-- 링크 -->
     <title>판다마켓</title>
-    <link rel="stylesheet" href="css/import.css" />
-    <link rel="icon" href="image/logo.png" />
+    <link rel="stylesheet" href="/css/import.css" />
+    <link rel="icon" href="/image/logo.png" />
   </head>
   <body>
     <!-- 작업 전 -->

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,6 +1,8 @@
 
 const inputs = document.querySelectorAll('.input_group');
-const password = document.querySelector('#user_password');
+const pw = document.querySelector('#user_password');
+const pwCheck = document.querySelector('#user_password_check');
+
 const form = document.querySelector('#authForm');
 const authBtn = document.querySelector('.auth.btn');
 
@@ -42,18 +44,28 @@ inputs.forEach(group =>{
     const emailPattern = /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,}$/;
 
     if(type === 'email' && !(emailPattern.test(values))){
-      errorText.textContent = `잘못된 ${labelText} 형식입니다.`;
+      errorText.textContent = '잘못된 이메일 형식입니다.';
       //비밀번호
-    }else if(type === 'password' && values.length < 8){
-      errorText.textContent = `${labelText}를 8자 이상 입력해주세요.`;
+    }else if(type === 'password'){
+      if(values.length < 8){
+        errorText.textContent = '비밀번호를 8자 이상 입력해주세요.';
+      }else if(values !== pwCheck.value){
+        const pwCheckError = pwCheck.closest('.input_warp').querySelector('.error_text');
+        pwCheckError.textContent = '비밀번호가 일치하지 않습니다..';
+      }else{
+        clearError(input, errorText);
+        clearError(pwCheck, pwCheckError);
+      }
+      
       //비밀번호 확인
-    }else if(type === 'password_check' && password.value !== values){
-      errorText.textContent = `${labelText}가 일치하지 않습니다..`;
+    }else if(type === 'password_check' && pw.value !== values){
+      errorText.textContent = '비밀번호가 일치하지 않습니다..';
+      //비밀번호 일치
     }else{
       clearError(input, errorText);
     }
     checkFormClick();
-  });
+  }); 
 
 })
 

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,0 +1,95 @@
+
+const inputs = document.querySelectorAll('.input_group');
+const password = document.querySelector('#user_password');
+const form = document.querySelector('#authForm');
+const authBtn = document.querySelector('.auth.btn');
+
+//forEach 공통 변수
+function groupInput(group){
+  const  input = group.querySelector('.input_text');
+  const  errorText = group.querySelector('.error_text');
+  const  type = group.dataset.type;
+  
+  return { input, errorText, type };
+}
+
+//error_text 초기화
+function clearError(target, text){
+  target.style.border = '';
+  text.textContent = '';
+}
+
+//input값 오류
+inputs.forEach(group =>{
+  const {input, errorText, type} = groupInput(group);
+  
+  //focusout
+  input.addEventListener('focusout', (e) => {
+    const target = e.target;
+    const values = target.value.trim();
+
+    const label = target.closest('.input_group').querySelector('label');
+    const labelText = label.textContent.trim();
+
+    //빈 값
+    if(values === ''){
+      target.style.border = '1px solid #ff0000';
+      errorText.textContent = `${labelText}을(를) 입력해주세요.`
+      return;
+    }
+
+    //이메일
+    const emailPattern = /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,}$/;
+
+    if(type === 'email' && !(emailPattern.test(values))){
+      errorText.textContent = `잘못된 ${labelText} 형식입니다.`;
+      //비밀번호
+    }else if(type === 'password' && values.length < 8){
+      errorText.textContent = `${labelText}를 8자 이상 입력해주세요.`;
+      //비밀번호 확인
+    }else if(type === 'password_check' && password.value !== values){
+      errorText.textContent = `${labelText}가 일치하지 않습니다..`;
+    }else{
+      clearError(input, errorText);
+    }
+    checkFormClick();
+  });
+
+})
+
+//submit버튼 활성화
+function checkFormClick(){
+
+  let isClick = true;
+
+  inputs.forEach(group =>{
+    const {input, errorText} = groupInput(group);
+
+    if (errorText.textContent.trim() !== '' || input.value.trim() === '') {
+      isClick = false;
+    }
+  });
+
+  authBtn.disabled = !isClick;
+  authBtn.style.backgroundColor = isClick ? 'var(--primary-100)' : 'var(--gray-400)';
+  authBtn.style.cursor = isClick ? 'pointer' : 'unset';
+}
+
+//패스워드 아이콘 활성화/비활성화
+const passwordIcon = document.querySelectorAll('.password_icon');
+
+passwordIcon.forEach( icons => {
+  const prevInput = icons.previousElementSibling;
+  icons.addEventListener('click', (e) => {
+    const target = e.target;
+    if(prevInput.type === 'password'){
+      target.classList.add('show');
+      prevInput.type = 'text'
+      target.textContent = 'visibility'
+    }else{
+      target.classList.remove('show');
+      prevInput.type = 'password'
+      target.textContent = 'visibility_off'
+    }
+  });
+});

--- a/login.html
+++ b/login.html
@@ -29,15 +29,21 @@
           </a>
           <form action="/login">
             <div class="user_input">
-              <div class="email_input">
+              <!-- 이메일 -->
+              <div class="input_group" data-type="email">
                 <label for="user_email">이메일</label>
-                <input class="text_tall" id="user_email" type="email" placeholder="이메일을 입력해주세요"/>
+                <div class="input_warp">
+                  <input class="text_tall input_text" id="user_email" type="email" placeholder="이메일을 입력해주세요" required/>
+                  <span class="error_text"></span>
+                </div>
               </div>
-              <div class="password_input">
+              <!-- 비밀번호 -->
+              <div class="input_group" data-type="password">
                 <label for="user_password">비밀번호</label>
-                <div class="password_view">
-                  <input class="text_tall" id="user_password" type="password" placeholder="비밀번호를 입력해주세요"/>
+                <div class="input_warp">
+                  <input class="text_tall input_text" id="user_password" type="password" placeholder="비밀번호를 입력해주세요" required/>
                   <span class="material-symbols-outlined password_icon">visibility_off</span>
+                  <span class="error_text"></span>
                 </div>
               </div>
               <button type="submit" class="auth btn text_tall" disabled>로그인</button>
@@ -57,5 +63,6 @@
           </div>
         </div>
     </section>
+    <script src="/js/auth.js"></script>
   </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -16,16 +16,15 @@
     <meta name="twitter:image" content="https://pandamarket-jieun.netlify.app/image/meta_padamarket.png" />
     <!-- 링크 -->
     <title>판다마켓</title>
-    <link rel="stylesheet" href="css/import.css" />
-    <link rel="stylesheet" href="css/auth.css" />
-    <link rel="icon" href="image/logo.png" />
+    <link rel="stylesheet" href="/css/import.css" />
+    <link rel="stylesheet" href="/css/auth.css" />
+    <link rel="icon" href="/image/logo.png" />
   </head>
   <body>
     <section class="auth_container">
-      <div class="auth_wrapper">
         <div class="width_container">
           <a href="/" class="logo">
-            <img src="image/logo.png" alt="판다로고" class="logo_img" />
+            <img src="/image/logo.png" alt="판다로고" class="logo_img" />
             <h1>판다마켓</h1>
           </a>
           <form action="/login">
@@ -48,8 +47,8 @@
             <span>간편 로그인하기</span>
             <div class="sns_login_wrapper">
               <ul class="sns_login">
-                <li class="icon_cover google"><a href="https://www.google.com/"><img src="image/sns_google.png" alt="구글아이콘" class="sns_icon"></a></li>
-                <li class="icon_cover kakao"><a href="https://www.kakaocorp.com/page/"><img src="image/sns_kakao.png" alt="카카오아이콘" class="sns_icon"></a></li>
+                <li class="icon_cover google"><a href="https://www.google.com/"><img src="/image/sns_google.png" alt="구글아이콘" class="sns_icon"></a></li>
+                <li class="icon_cover kakao"><a href="https://www.kakaocorp.com/page/"><img src="/image/sns_kakao.png" alt="카카오아이콘" class="sns_icon"></a></li>
               </ul>
             </div>
           </div>
@@ -57,7 +56,6 @@
             <span class="auth_text">판다마켓이 처음이신가요?<a href="/signup" class="auth_link">회원가입</a></span>
           </div>
         </div>
-      </div>
     </section>
   </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -16,8 +16,8 @@
     <meta name="twitter:image" content="https://pandamarket-jieun.netlify.app/image/meta_padamarket.png" />
     <!-- 링크 -->
     <title>판다마켓</title>
-    <link rel="stylesheet" href="css/import.css" />
-    <link rel="icon" href="image/logo.png" />
+    <link rel="stylesheet" href="/css/import.css" />
+    <link rel="icon" href="/image/logo.png" />
   </head>
   <body>
     <!-- 작업 전 -->

--- a/signup.html
+++ b/signup.html
@@ -16,51 +16,49 @@
     <meta name="twitter:image" content="https://pandamarket-jieun.netlify.app/image/meta_padamarket.png" />
     <!-- 링크 -->
     <title>판다마켓</title>
-    <link rel="stylesheet" href="css/import.css" />
-    <link rel="stylesheet" href="css/auth.css" />
-    <link rel="icon" href="image/logo.png" />
+    <link rel="stylesheet" href="/css/import.css" />
+    <link rel="stylesheet" href="/css/auth.css" />
+    <link rel="icon" href="/image/logo.png" />
   </head>
   <body>
     <section class="auth_container">
-      <div class="auth_wrapper">
-        <div class="width_container">
-          <a href="/" class="logo">
-            <img src="image/logo.png" alt="판다로고" class="logo_img" />
-            <h1>판다마켓</h1>
-          </a>
-          <form action="/signup">
-            <div class="user_input">
-              <div class="email_input">
-                <label for="user_email">이메일</label>
-                <input class="text_tall" id="user_email" type="email" placeholder="이메일을 입력해주세요"/>
-              </div>
-              <div class="password_input">
-                <label for="user_password">비밀번호</label>
-                <div class="password_view">
-                  <input class="text_tall" id="user_password" type="password" placeholder="비밀번호를 입력해주세요"/>
-              </div>
-              <div class="password_input check">
-                <label for="user_password_check">비밀번호 확인</label>
-                <div class="password_view">
-                  <input class="text_tall" id="user_password_check" type="password" placeholder="비밀번호를 다시 한 번 입력해주세요"/>
-                  <span class="material-symbols-outlined password_icon">visibility_off</span>
-                </div>
-              </div>
-              <button type="submit" class="auth btn text_tall" disabled>로그인</button>
+      <div class="width_container">
+        <a href="/" class="logo">
+          <img src="/image/logo.png" alt="판다로고" class="logo_img" />
+          <h1>판다마켓</h1>
+        </a>
+        <form action="/signup">
+          <div class="user_input">
+            <div class="email_input">
+              <label for="user_email">이메일</label>
+              <input class="text_tall" id="user_email" type="email" placeholder="이메일을 입력해주세요"/>
             </div>
-          </form>
-          <div class="simple_login">
-            <span>간편 로그인하기</span>
-            <div class="sns_login_wrapper">
-              <ul class="sns_login">
-                <li class="icon_cover"><a href="https://www.google.com/" class="google_login"><img src="image/sns_google.png" alt="구글아이콘"></a></li>
-                <li class="icon_cover"><a href="https://www.kakaocorp.com/page/" id="kakao_login"><img src="image/sns_kakao.png" alt="카카오아이콘"></a></li>
-              </ul>
+            <div class="password_input">
+              <label for="user_password">비밀번호</label>
+              <div class="password_view">
+                <input class="text_tall" id="user_password" type="password" placeholder="비밀번호를 입력해주세요"/>
             </div>
+            <div class="password_input check">
+              <label for="user_password_check">비밀번호 확인</label>
+              <div class="password_view">
+                <input class="text_tall" id="user_password_check" type="password" placeholder="비밀번호를 다시 한 번 입력해주세요"/>
+                <span class="material-symbols-outlined password_icon">visibility_off</span>
+              </div>
+            </div>
+            <button type="submit" class="auth btn text_tall" disabled>로그인</button>
           </div>
-          <div class="auth_helper">
-            <span class="auth_text">이미 회원이신가요?<a href="/login"  class="auth_link">로그인</a></span>
+        </form>
+        <div class="simple_login">
+          <span>간편 로그인하기</span>
+          <div class="sns_login_wrapper">
+            <ul class="sns_login">
+              <li class="icon_cover"><a href="https://www.google.com/" class="google_login"><img src="/image/sns_google.png" alt="구글아이콘"></a></li>
+              <li class="icon_cover"><a href="https://www.kakaocorp.com/page/" id="kakao_login"><img src="/image/sns_kakao.png" alt="카카오아이콘"></a></li>
+            </ul>
           </div>
+        </div>
+        <div class="auth_helper">
+          <span class="auth_text">이미 회원이신가요?<a href="/login"  class="auth_link">로그인</a></span>
         </div>
       </div>
     </section>

--- a/signup.html
+++ b/signup.html
@@ -27,25 +27,43 @@
           <img src="/image/logo.png" alt="판다로고" class="logo_img" />
           <h1>판다마켓</h1>
         </a>
-        <form action="/signup">
+        <form action="/signup" id="authForm">
           <div class="user_input">
-            <div class="email_input">
+            <!-- 이메일 -->
+            <div class="input_group" data-type="email">
               <label for="user_email">이메일</label>
-              <input class="text_tall" id="user_email" type="email" placeholder="이메일을 입력해주세요"/>
-            </div>
-            <div class="password_input">
-              <label for="user_password">비밀번호</label>
-              <div class="password_view">
-                <input class="text_tall" id="user_password" type="password" placeholder="비밀번호를 입력해주세요"/>
-            </div>
-            <div class="password_input check">
-              <label for="user_password_check">비밀번호 확인</label>
-              <div class="password_view">
-                <input class="text_tall" id="user_password_check" type="password" placeholder="비밀번호를 다시 한 번 입력해주세요"/>
-                <span class="material-symbols-outlined password_icon">visibility_off</span>
+              <div class="input_warp">
+                <input class="text_tall input_text" id="user_email" type="email" placeholder="이메일을 입력해주세요" required/>
+                <span class="error_text"></span>
               </div>
             </div>
-            <button type="submit" class="auth btn text_tall" disabled>로그인</button>
+            <!-- 닉네임 -->
+            <div class="input_group" data-type="nick">  
+              <label for="user_nick">닉네임</label>
+              <div class="input_warp">
+                <input class="text_tall input_text" id="user_nick" type="text" placeholder="닉네임을 입력해주세요" required/>
+                <span class="error_text"></span>
+              </div>
+            </div>
+            <!-- 비밀번호 -->
+            <div class="input_group" data-type="password">
+              <label for="user_password">비밀번호</label>
+              <div class="input_warp">
+                <input class="text_tall input_text" id="user_password" type="password" placeholder="비밀번호를 입력해주세요" required/>
+                <span class="material-symbols-outlined password_icon">visibility_off</span>
+                <span class="error_text"></span>
+              </div>
+            </div>
+            <!-- 비밀번호 확인 -->
+            <div class="input_group" data-type="password_check">
+              <label for="user_password_check">비밀번호 확인</label>
+              <div class="input_warp">
+                <input class="text_tall input_text" id="user_password_check" type="password" placeholder="비밀번호를 다시 한 번 입력해주세요" required/>
+                <span class="material-symbols-outlined password_icon">visibility_off</span>
+                <span class="error_text"></span>
+              </div>
+            </div>
+            <button type="submit" class="auth btn text_tall" disabled>회원가입</button>
           </div>
         </form>
         <div class="simple_login">
@@ -62,5 +80,6 @@
         </div>
       </div>
     </section>
+    <script src="/js/auth.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## 요구사항

- [x] Github에 PR(Pull Request)을 만들어서 미션을 제출합니다.
- [x] 피그마 디자인에 맞게 페이지를 만들어 주세요.
- [x] React와 같은 UI 라이브러리를 사용하지 않고 진행합니다.

### 기본

로그인
- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 "이메일을 입력해주세요." 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 "잘못된 이메일 형식입니다" 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 "비밀번호를 입력해주세요." 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 "비밀번호를 8자 이상 입력해주세요." 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 '로그인' 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 '로그인' 버튼이 활성화 됩니다.
- [x] 활성화된 '로그인' 버튼을 누르면 "/items" 로 이동합니다

회원가입
- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 "이메일을 입력해주세요." 빨강색 에러 메세지를 보입니다.
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 경우 input에 빨강색 테두리와 아래에 "잘못된 이메일 형식입니다" 빨강색 에러 메세지를 보입니다.
- [x]  닉네임 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 "닉네임을 입력해주세요." 빨강색 에러 메세지를 보입니다.
- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 "비밀번호를 입력해주세요." 에러 메세지를 보입니다
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만일 경우 아래에 "비밀번호를 8자 이상 입력해주세요." 에러 메세지를 보입니다.
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 "비밀번호가 일치하지 않습니다.." 에러 메세지를 보입니다.
- [x] input 에 빈 값이 있거나 에러 메세지가 있으면 '회원가입' 버튼은 비활성화 됩니다.
- [x] input 에 유효한 값을 입력하면 '회원가입' 버튼이 활성화 됩니다.
- [x] 활성화된 '회원가입' 버튼을 누르면 로그인 페이지로 이동합니다

### 심화
- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이도록 합니다.

## 주요 변경사항

 - 

## 스크린샷

## 멘토에게
- 제가 쓴 코드에서 더 효율적인 방법이 뭐가 있는지 더 알고싶습니다.
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
